### PR TITLE
Minor modification for oSPARC deploy

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask_question.md
+++ b/.github/ISSUE_TEMPLATE/ask_question.md
@@ -1,0 +1,17 @@
+---
+name: 💬 Question
+about: Ask a question
+labels: question
+assignees: elisabettai, OmkarAthavale
+---
+
+## What version of this service are you using?
+
+<!--
+Check in osparc UI: 
+- Search for 'math' under SERVICES
+- Open the info dialog 
+- Copy& paste here the service KEY and VERSION. e.g. simcore/services/dynamic/jupyter-math 2.0.8
+-->
+
+## How can we help you?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: 🐛 Bug
+about: File a bug/issue
+labels: bug
+assignees: elisabettai, OmkarAthavale
+---
+
+## What version of this service are you using?
+
+<!--
+Check in osparc UI: 
+- Search for 'math' under SERVICES
+- Open the info dialog 
+- Copy& paste here the service KEY and VERSION. e.g. simcore/services/dynamic/jupyter-math 2.0.8
+-->
+
+## Long story short
+
+<!-- Please describe your problem and why the fix is important. -->
+
+## Expected behaviour
+
+<!-- What is the behaviour you expect? -->
+
+## Actual behaviour
+
+<!-- What's actually happening? -->
+
+## Steps to reproduce
+
+<!-- Please describe steps to reproduce the issue.
+     If you have a script that does that please include it here within
+     markdown code markup -->
+
+## Your environment
+
+<!-- Describe the environment you have that lead to your issue.
+     This includes aiohttp version, OS, proxy server and other bits that
+     are related to your case.
+
+     IMPORTANT: aiohttp is both server framework and client library.
+     For getting rid of confusing please put 'server', 'client' or 'both'
+     word here.
+     -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: ✨  Feature request
+about: Suggest an idea to implement
+labels: enhancement
+assignees: elisabettai, OmkarAthavale
+---
+
+## User Story
+
+<!-- A clear and concise description of how the feature works and looks like from the user's perspective.
+
+Ex. I want to be able the stop the running pipeline by pressing a stop button. If the pipeline is stopped, I see a info-level message confirming it in the logger, if it fails the message should be displayed in red (error). Also, all the progress bars in the nodes must be set to 0. -->
+
+## Example
+
+<!-- Any file/screenshot/photomontage/video/website is provided for a better understanding of the request -->
+
+
+## Definition of Done
+<!--
+A clear and concise description of what the feature requires.
+
+1. Play button turns into stop button when pipeline is running
+2. Stop button turns into play button when pipeline is finished
+3. Stop button turns into play button when pipeline is successfully stopped
+4. Logger displays messages everytime the play/stop button is pressed
+5. Progress bars are set to 0 when stopping pipeline
+6. Stop button has a Python interface -->

--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -1,0 +1,22 @@
+name: Build and check image
+
+on: push
+
+jobs:
+  verify-image-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo content
+        uses: actions/checkout@v2
+      - name: ooil version
+        uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-43
+        with:
+          args: ooil --version
+      - name: Assemble docker-compose spec
+        uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-43
+        with:
+          args: ooil compose
+      - name: Build all images if multiple
+        uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-43
+        with:
+          args: docker-compose build

--- a/.osparc/metadata.yml
+++ b/.osparc/metadata.yml
@@ -10,6 +10,9 @@ authors:
   - name: Omkar N. Athavale
     email: oath399@aucklanduni.ac.nz
     affiliation: Auckland Bioengineering Institute, University of Auckland
+  - name: Elisabetta Iavarone
+    email: iavarone@itis.swiss
+    affiliation: IT'IS Foundation
 inputs:
   input_1:
     displayOrder: 1
@@ -33,4 +36,3 @@ outputs:
     type: data:*/*
     fileToKeyMap:
       config.json: output_1
-  

--- a/.osparc/metadata.yml
+++ b/.osparc/metadata.yml
@@ -32,5 +32,5 @@ outputs:
     description: OpenCOR Docker Config File
     type: data:*/*
     fileToKeyMap:
-      output_1.json: output_1
+      config.json: output_1
   

--- a/.osparc/metadata.yml
+++ b/.osparc/metadata.yml
@@ -5,7 +5,7 @@ integration-version: 1.0.0
 version: 0.1.0
 description: Generates OpenCOR config file with selected parameters for ICC_SMC_Neuro CellML model
 contact: oath399@aucklanduni.ac.nz
-thumbnail: https://github.com/ITISFoundation/osparc-assets/blob/cb43207b6be2f4311c93cd963538d5718b41a023/assets/default-thumbnail-cookiecutter-osparc-service.png?raw=true
+thumbnail: https://opencor.ws/res/pics/logo.png
 authors:
   - name: Omkar N. Athavale
     email: oath399@aucklanduni.ac.nz

--- a/service.cli/execute.sh
+++ b/service.cli/execute.sh
@@ -25,6 +25,5 @@ python3 main.py $INPUT_1 $INPUT_2
 # as defined in the output labels
 # For example: cp output.csv $OUTPUT_FOLDER or to $OUTPUT_FOLDER/outputs.json using jq
 #TODO: Replace following
-cp config.json  "${OUTPUT_FOLDER}"/
-EOF
+cp config.json  "${OUTPUT_FOLDER}"
 

--- a/service.cli/execute.sh
+++ b/service.cli/execute.sh
@@ -25,6 +25,6 @@ python3 main.py $INPUT_1 $INPUT_2
 # as defined in the output labels
 # For example: cp output.csv $OUTPUT_FOLDER or to $OUTPUT_FOLDER/outputs.json using jq
 #TODO: Replace following
-cp config.json  "${OUTPUT_FOLDER}"/outputs.json
+cp config.json  "${OUTPUT_FOLDER}"/
 EOF
 


### PR DESCRIPTION
Some changes after testing that everything works in a local deployment of oSPARC.
- renamed output file to config.json (so it is picked up as output_1)
- Copy output file to the OUTPUT_FOLDER: I assume `config.json` is the only output and it is a file, so to retrieve it as output of the service, we just need to copy the file to OUTPUT_FOLDER (in `execute.sh` script)
- Added a CI GitHub file (`.github/check-image.yml`) that let GitHub check that the image can be built. Once we have a "green" CI, we can monitor the repository for automatically publishing new versions of the service in oSPARC.

Minors:
- Service thumbnail (please edit if you don't like it 😉)
- GitHub issue templates
- Added also myself as author, so people can also report issues to me if somethings pops up.