### PR TITLE
Bugfix: run script was missing

### DIFF
--- a/.osparc/metadata.yml
+++ b/.osparc/metadata.yml
@@ -2,17 +2,18 @@ name: Config_Service_ICC_SMC_Neuro
 key: simcore/services/comp/config_service_icc_smc_neuro
 type: computational
 integration-version: 1.0.0
-version: 0.1.0
-description: Generates OpenCOR config file with selected parameters for ICC_SMC_Neuro CellML model
+version: 0.1.1
+description: Generates OpenCOR config file with selected parameters for ICC_SMC_Neuro
+  CellML model
 contact: oath399@aucklanduni.ac.nz
 thumbnail: https://opencor.ws/res/pics/logo.png
 authors:
-  - name: Omkar N. Athavale
-    email: oath399@aucklanduni.ac.nz
-    affiliation: Auckland Bioengineering Institute, University of Auckland
-  - name: Elisabetta Iavarone
-    email: iavarone@itis.swiss
-    affiliation: IT'IS Foundation
+- name: Omkar N. Athavale
+  email: oath399@aucklanduni.ac.nz
+  affiliation: Auckland Bioengineering Institute, University of Auckland
+- name: Elisabetta Iavarone
+  email: iavarone@itis.swiss
+  affiliation: IT'IS Foundation
 inputs:
   input_1:
     displayOrder: 1
@@ -20,14 +21,12 @@ inputs:
     description: Inhibitory stimulation (0-1)
     type: number
     defaultValue: 0
-
   input_2:
     displayOrder: 2
     label: x<sub>e</sub>
     description: Excitatory stimulation (0-1)
     type: number
     defaultValue: 0
-
 outputs:
   output_1:
     displayOrder: 1

--- a/service.cli/run
+++ b/service.cli/run
@@ -1,0 +1,19 @@
+
+#!/bin/sh
+#---------------------------------------------------------------
+# AUTO-GENERATED CODE, do not modify this will be overwritten!!!
+#---------------------------------------------------------------
+# shell strict mode:
+set -o errexit
+set -o nounset
+IFS=$(printf '\n\t')
+cd "$(dirname "$0")"
+json_input=$INPUT_FOLDER/inputs.json
+    
+INPUT_1=$(< "$json_input" jq '.input_1')
+export INPUT_1
+INPUT_2=$(< "$json_input" jq '.input_2')
+export INPUT_2
+
+exec execute.sh
+    


### PR DESCRIPTION
While developing the service, we forgot to add the `service.cli/run` to version control. For this reason, the service is not able to start in osparc.io (error log was sent by email from @OmkarAthavale).

The `run` script is called at the end of the `Dockerfile` to start-up the service and get the inputs.